### PR TITLE
Implement browserifyIncremental into js:dev flow.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -92,6 +92,7 @@
     "predef"        : [
         "require",
         "module",
-        "process"
+        "process",
+        "global"
     ]       // additional predefined global variables
 }

--- a/app/js/pages/home.js
+++ b/app/js/pages/home.js
@@ -23,6 +23,7 @@ module.exports = View.extend({
     //   el: this.$('[role="quote-box"]')
     // });
 
+
     this.postsView = new PostsView({
       collection: app.posts,
       el: this.$('[role="posts-collection"]')

--- a/gulp/build.js
+++ b/gulp/build.js
@@ -15,6 +15,7 @@ var exec = require('child_process').exec;
 var source = require('vinyl-source-stream');
 var browserify = require('browserify');
 var istanbul = require('browserify-istanbul');
+var browserifyIncremental = require('browserify-incremental');
 var browserSync = require('browser-sync');
 var templatizer = require('templatizer');
 var penthouse = require('penthouse');
@@ -131,10 +132,15 @@ gulp.task('js:istanbul', ['templates', 'posts'], function () {
 
 // Bundles Browserify with sourcemaps.
 gulp.task('js:dev', ['templates', 'posts'], function () {
-  var bundleStream = browserify({
+  // Incremental development bundle.
+  // Stored as a global variable so it can be reused
+  // between compiles by `browserify-incremental`
+  global.incDevBundle = global.incDevBundle || browserifyIncremental({
       entries: paths.app + '/js/main.js',
       debug: true
-    })
+    });
+
+  var bundleStream = global.incDevBundle
     .bundle()
     .on('error', config.handleError);
 

--- a/package.json
+++ b/package.json
@@ -27,15 +27,16 @@
   },
   "homepage": "https://github.com/readfwd/macovei",
   "devDependencies": {
+    "browserify-incremental": "^0.1.2",
     "coveralls": "^2.11.1",
-    "ngrok": "^0.1.97",
     "karma": "^0.12.19",
     "karma-coverage": "git://github.com/readfwd/karma-coverage.git#61216c0",
     "karma-mocha": "^0.1.6",
     "karma-mocha-reporter": "^0.2.8",
     "karma-osx-reporter": "^0.1.0",
     "karma-phantomjs-launcher": "^0.1.4",
-    "mocha": "^1.21.3"
+    "mocha": "^1.21.3",
+    "ngrok": "^0.1.97"
   },
   "dependencies": {
     "ampersand-router": "^1.0.2",


### PR DESCRIPTION
Reduces `js:dev` task time to roughly `50ms` after initial one.

`js:dev` as a whole still takes longer than it should because of the fact that it depends on `templates` and `posts`, which isn't really necessary when you're just changing 1 JavaScript file.

Don't forget to `npm install`.
